### PR TITLE
pick right key of payment state change event

### DIFF
--- a/MarketplaceCore-app/services/payment_service.js
+++ b/MarketplaceCore-app/services/payment_service.js
@@ -46,7 +46,7 @@ payment_service.socket.on('connect', function () {
     logger.debug("connected to paymentservice");
 });
 
-payment_service.socket.on('StateChange', function (invoice) {
+payment_service.socket.on('StateChange', function (invoice) { // FIXME the paramter is the state of the payment, not the invoice
     logger.debug("PaymentService StateChange: " + invoice);
     invoice = JSON.parse(invoice);
 
@@ -55,7 +55,7 @@ payment_service.socket.on('StateChange', function (invoice) {
         var paymentData = {
             transactionUUID: invoice.referenceId,
             extInvoiceId: invoice.invoiceId,
-            depth: invoice.depth,
+            depth: invoice.depthInBlocks,
             confidenceState: invoice.state,
             bitcoinTransaction: null
         };


### PR DESCRIPTION
The right key to read the number of confirmations for a change state event via socket.io from the payment service is `depthInBlocks`, see https://github.com/IUNO-TDM/PaymentService/commit/687482dffc1e118aa95e65dae4b5a16eecff81b4.

This PR corrects the MarketplaceCore to grab the value of the right key and adds a remark about a misleading name of a variable.